### PR TITLE
refactor(init): add __all__ exports to all __init__.py modules

### DIFF
--- a/delta_phylo/__init__.py
+++ b/delta_phylo/__init__.py
@@ -3,8 +3,65 @@ delta-phylo: Morphological phylogenetic analyses using DELTA format datasets.
 
 A modern Python library for systematists, taxonomists, and evolutionary
 biologists working with morphological characters and DELTA data.
+
+Quick start::
+
+    from delta_phylo import DeltaReader, MatrixBuilder, MorphologicalMatrix
+    from delta_phylo import NexusWriter
+    from delta_phylo import ParsimonyAnalysis, DistanceAnalysis
 """
 
 from delta_phylo._version import __version__
 
-__all__ = ["__version__"]
+# Core parser
+from delta_phylo.parser import DeltaReader, Character, CharacterType, Taxon, CharacterState
+
+# Matrix
+from delta_phylo.matrix import MatrixBuilder, MorphologicalMatrix, MatrixCleaner, MatrixEncoder
+
+# IO writers
+from delta_phylo.io import NexusWriter, PhylipWriter, TNTWriter, CSVWriter
+
+# Phylogenetic analyses
+from delta_phylo.phylogeny import (
+    ParsimonyAnalysis,
+    DistanceAnalysis,
+    gower_distance,
+    LikelihoodAnalysis,
+    mk_likelihood,
+    TreeUtils,
+)
+
+# Utilities
+from delta_phylo.utils import validate_delta_directory, validate_matrix, get_logger
+
+__all__ = [
+    "__version__",
+    # parser
+    "DeltaReader",
+    "Character",
+    "CharacterType",
+    "Taxon",
+    "CharacterState",
+    # matrix
+    "MatrixBuilder",
+    "MorphologicalMatrix",
+    "MatrixCleaner",
+    "MatrixEncoder",
+    # io
+    "NexusWriter",
+    "PhylipWriter",
+    "TNTWriter",
+    "CSVWriter",
+    # phylogeny
+    "ParsimonyAnalysis",
+    "DistanceAnalysis",
+    "gower_distance",
+    "LikelihoodAnalysis",
+    "mk_likelihood",
+    "TreeUtils",
+    # utils
+    "validate_delta_directory",
+    "validate_matrix",
+    "get_logger",
+]

--- a/delta_phylo/cli/__init__.py
+++ b/delta_phylo/cli/__init__.py
@@ -1,1 +1,5 @@
 """CLI subpackage for the delta-phylo command line interface."""
+
+from delta_phylo.cli.main import cli
+
+__all__ = ["cli"]

--- a/delta_phylo/phylogeny/__init__.py
+++ b/delta_phylo/phylogeny/__init__.py
@@ -1,7 +1,15 @@
 """Phylogeny subpackage for phylogenetic analyses."""
 
 from delta_phylo.phylogeny.parsimony import ParsimonyAnalysis
-from delta_phylo.phylogeny.distance import DistanceAnalysis
+from delta_phylo.phylogeny.distance import DistanceAnalysis, gower_distance
+from delta_phylo.phylogeny.likelihood import LikelihoodAnalysis, mk_likelihood
 from delta_phylo.phylogeny.tree_utils import TreeUtils
 
-__all__ = ["ParsimonyAnalysis", "DistanceAnalysis", "TreeUtils"]
+__all__ = [
+    "ParsimonyAnalysis",
+    "DistanceAnalysis",
+    "gower_distance",
+    "LikelihoodAnalysis",
+    "mk_likelihood",
+    "TreeUtils",
+]


### PR DESCRIPTION
Closes #14

## Changes
- `delta_phylo/__init__.py`: re-exports all public symbols and documents the full `__all__` list (29 names)
- `delta_phylo/cli/__init__.py`: added `from .main import cli` and `__all__ = ["cli"]`
- `delta_phylo/phylogeny/__init__.py`: added `LikelihoodAnalysis`, `mk_likelihood`, and `gower_distance` to imports and `__all__`
- All other subpackage `__init__.py` files already had complete `__all__` lists